### PR TITLE
Fix instructions for running python server

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -38,18 +38,16 @@ Start the data feed server by running:
 
 <code> python server.py</code>
 
-Run <code>npm install</code> to start the application.
-
-To run the app in development mode, run <code>npm start</code> in the project directory.
-
-Open http://localhost:3000 to view the app in the browser. The page will reload if you make edits.
-
 <h2>Run</h2>
 To start the server, run
 
 	python server.py
 
 this will create random market called 'test.csv' in your working directory if one does not already exist.
+
+If you encounter an issue with `datautil.parser`, run this command: 
+
+	pip install python-dateutil
 
 To start the example client, run:
 

--- a/README.markdown
+++ b/README.markdown
@@ -49,6 +49,8 @@ If you encounter an issue with `datautil.parser`, run this command:
 
 	pip install python-dateutil
 
+If you don't have pip, you can install it from: https://pip.pypa.io/en/stable/installing/
+
 To start the example client, run:
 
 	python client.py


### PR DESCRIPTION
Removed mentions of `npm start` in JPMC-tech-task-1.

Added error checking for running python server.